### PR TITLE
Fixed error handling + eventSource postMessage typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8876,6 +8876,14 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -9292,6 +9300,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "faye-websocket": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@open-rpc/client-js": "^1.2.4",
+    "eth-rpc-errors": "^4.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }


### PR DESCRIPTION
Fixed error handling by pulling in the eth-rpc-errors lib similar to what we did here in snaps: https://github.com/MetaMask/iframe-ee-openrpc-inspector-transport/blob/main/src/IframeInspectorTransportPlugin.ts#L64

also similar to the snaps code i converted it to use `eventSource` and coerce the type.


<img width="1706" alt="image" src="https://user-images.githubusercontent.com/364566/157120130-5149f324-9d76-4733-8900-79503f0aaf31.png">
