### PR TITLE
chore: add engines.node to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "tslint": "^5.17.0",
     "typescript": "^3.9.7"
   },
+  "engines": {
+    "node": "^16.20 || ^18.16 || >=20"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
Indicates minimum supported version as Node.js 16.